### PR TITLE
chore: Add a git alias to remove gone branches

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -36,3 +36,4 @@
 	ch = "!git checkout $(git branch -vv | grep -v '^\\*' | fzf | awk '{print $1}')"
 	b0 = "!git branch | awk '/^\\*/{print $2}'"
 	back = "!git branch backup-`git b0`"
+	gone = "!git fetch -p && git for-each-ref --format '%(refname:short) %(upstream:track)' | awk '$2 == \"[gone]\" {print $1}' | xargs -r git branch -D"


### PR DESCRIPTION
## Description

`.gitconfig`에 새로운 alias를 추가함. 새로 추가된 `git gone` 명령어는 아래 두 가지를 실행함:

1. `git fetch -p`를 통해 prune 처리 (지워진 원격 브랜치 정보 갱신)
2. 지워진 원격 브랜치를 트래킹하는 로컬 브랜치를 모두 삭제

> 트래킹하는 원격 브랜치가 없는 로컬 브랜치는 지워지지 않음