### PR TITLE
chore: Use bD alias in gone alias

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -36,4 +36,4 @@
 	ch = "!git checkout $(git branch -vv | grep -v '^\\*' | fzf | awk '{print $1}')"
 	b0 = "!git branch | awk '/^\\*/{print $2}'"
 	back = "!git branch backup-`git b0`"
-	gone = "!git fetch -p && git for-each-ref --format '%(refname:short) %(upstream:track)' | awk '$2 == \"[gone]\" {print $1}' | xargs -r git branch -D"
+	gone = "!git fetch -p && git for-each-ref --format '%(refname:short) %(upstream:track)' | awk '$2 == \"[gone]\" {print $1}' | xargs -r git bD"


### PR DESCRIPTION
## Description

gone alias에서 `git branch -D`를 `bD` alias를 사용하여 축약함.