### PR TITLE
chore: Highlight current column and line in vim

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -7,6 +7,8 @@ set incsearch
 
 set nu
 set ruler
+set cursorcolumn
+set cursorline
 
 set bs=indent,eol,start
 set background=dark


### PR DESCRIPTION
## Description

vim에서 cursor의 column과 line이 highlight되도록 다음 설정을 추가함:

```vim
set cursorcolumn
set cursorline
```