### PR TITLE
Revert "chore: Add licensed to brew"

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -19,7 +19,6 @@ brew "htop"
 brew "jq"
 brew "k3d"
 brew "kubernetes-cli"
-brew "licensed"
 brew "minikube"
 brew "mysql", restart_service: true
 brew "nvm"


### PR DESCRIPTION
## Description

Reverts jongwooo/dotfiles#36

licensed@4.x이 아닌 licensed@3.9.0을 사용하기 위해 homebrew에서 `licensed` 를 제거함.