### PR TITLE
chore: Remove licensed from brew

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -19,7 +19,6 @@ brew "htop"
 brew "jq"
 brew "k3d"
 brew "kubernetes-cli"
-brew "licensed"
 brew "minikube"
 brew "mysql", restart_service: true
 brew "nvm"


### PR DESCRIPTION
## Description

[licensed-3.9.0-darwin-x64.tar.gz](https://github.com/github/licensed/releases/download/3.9.0/licensed-3.9.0-darwin-x64.tar.gz)를 사용하기 위해 homebrew에서 `licensed@1.5.0`을 제거함. 

### Related Issues/PRs

#37 