### PR TITLE
fix: Resolve YouCompleteMe unavailable error

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -23,7 +23,7 @@ brew "kubernetes-cli"
 brew "minikube"
 brew "mysql", restart_service: true
 brew "nvm"
-brew "ruby"
+brew "python@3.10"
 brew "the_silver_searcher"
 brew "tig"
 brew "tree"


### PR DESCRIPTION
## Description

> YouCompleteMe unavailable: requires Vim compiled with Python (3.6.0+) support.

`vim` 삭제 후 재설치를 통해 위의 에러를 해결함.