### PR TITLE
refactor: Use $SDKMAN_DIR and $GVM_DIR instead of $HOME

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -27,10 +27,10 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && . "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
 
 export SDKMAN_DIR="$HOME/.sdkman"
-[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ] && source "$HOME/.sdkman/bin/sdkman-init.sh"
+[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ] && source "$SDKMAN_DIR/bin/sdkman-init.sh"
 
 export GVM_DIR="$HOME/.gvm"
-[ -s "$HOME/.gvm/scripts/gvm" ] && source "$HOME/.gvm/scripts/gvm"
+[ -s "$GVM_DIR/scripts/gvm" ] && source "$GVM_DIR/scripts/gvm"
 
 eval "$(github-copilot-cli alias -- "$0")"
 alias vim="nvim"


### PR DESCRIPTION
## Description

`$HOME` 대신 `$SDKMAN_DIR`과  `$GVM_DIR`을 사용하도록 변경함 .