### PR TITLE
chore: Add kubectl --dry-run alias

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -44,4 +44,5 @@ eval "$(github-copilot-cli alias -- "$0")"
 
 alias vim="nvim"
 alias k="kubectl"
+alias kdry="kubectl --dry-run=client -o yaml"
 alias tf="terraform"


### PR DESCRIPTION
## Description

`kubectl --dry-run client -o yaml` alias (`kdry`)를 추가함.